### PR TITLE
Add option to configure bot to forward all message

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Set `inboxName` with `null` if you don't want use groups:
 }
 ```
 
+> [!IMPORTANT]
+> If you want to forwards all messages, enable `withoutAuthorizedUsers`. But you should know risk, all messages including others using this message also would be handled, because without authorization.
+
 ## Usage notice
 - Please, consider that messages will be pulled from Telegram only if Logseq desktop application running.
 - If you doesn't open Logseq application more than 24 hours, messages from Telegram will be lost and you need to resend it.

--- a/index.ts
+++ b/index.ts
@@ -433,7 +433,10 @@ function getMessages(): Promise<IMessagesList[] | undefined> {
         if (response && response.data && response.data.ok) {
           const resArr = response.data.result;
 
-          resArr.forEach((element: IUpdate) => {
+
+          for (const res of resArr) {
+            const element: IUpdate = res;
+
             updateId = element.update_id;
             if (
               element.message &&
@@ -445,7 +448,7 @@ function getMessages(): Promise<IMessagesList[] | undefined> {
               if(!withoutAuthorizedUsers) {
                 if(!element.message.from.username) {
                   // NOTE: when not set all messages forwards setting && without username, do nothing
-                  return;
+                  continue;
                 }
 
                 const authorizedUsers: string[] =
@@ -507,7 +510,7 @@ function getMessages(): Promise<IMessagesList[] | undefined> {
                 text,
               });
             }
-          });
+          }
 
           await logseq.updateSettings({
             updateId,

--- a/index.ts
+++ b/index.ts
@@ -147,6 +147,13 @@ function applySettingsSchema() {
       title: "Title in daily journal",
     },
     {
+      key: "withoutAuthorizedUsers",
+      description: "⚠️ RISK: Any message who send to bot will be handled. Learn more in readme file. If enabled, all messages will be pasted in graph.",
+      type: "boolean",
+      default: false,
+      title: "Forward all message without authorizedUsers",
+    },
+    {
       key: "authorizedUsers",
       description:
         "Be sure to add your username in authorizedUsers array, because your recently created bot is publicly findable and other peoples may send messages to your bot. For example \"authorizedUsers\": [\"your_username\"]. If you leave this array empty - all messages from all users will be processed!",
@@ -431,18 +438,26 @@ function getMessages(): Promise<IMessagesList[] | undefined> {
             if (
               element.message &&
               element.message.text &&
-              element.message.date &&
-              element.message.from.username
+              element.message.date
             ) {
-              const authorizedUsers: string[] =
-                logseq.settings!.authorizedUsers;
-              if (authorizedUsers && authorizedUsers.length > 0) {
-                if (!authorizedUsers.includes(element.message.from.username)) {
-                  log({
-                    name: "Ignore messages, user not authorized",
-                    element,
-                  });
+              const withoutAuthorizedUsers: boolean =
+                logseq.settings!.withoutAuthorizedUsers;
+              if(!withoutAuthorizedUsers) {
+                if(!element.message.from.username) {
+                  // NOTE: when not set all messages forwards setting && without username, do nothing
                   return;
+                }
+
+                const authorizedUsers: string[] =
+                  logseq.settings!.authorizedUsers;
+                if (authorizedUsers && authorizedUsers.length > 0) {
+                  if (!authorizedUsers.includes(element.message.from.username)) {
+                    log({
+                      name: "Ignore messages, user not authorized",
+                      element,
+                    });
+                    return;
+                  }
                 }
               }
 


### PR DESCRIPTION
Add support to forward all message from any user, even without username. This option will ignore the `authorizedUsers`. This would disable by default.

![图片](https://github.com/user-attachments/assets/fea8c214-1d52-4488-9853-aca2480a4b53)

Usecase Screenshot is following:

![图片](https://github.com/user-attachments/assets/91ef706a-b8fa-4d4c-98bb-c3a53e699ee4)

In my test, this changes could forward channel messages as well.

![图片](https://github.com/user-attachments/assets/18039b2d-969a-432b-8eed-7ee9e2709821)

Any suggestion would be appreciated!

issue via: https://github.com/shady2k/logseq-inbox-telegram-plugin/issues/25#issuecomment-2408867582